### PR TITLE
Migrate to the v2 UWPSC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Contact an admin / contributor of the project for the template url and paste it 
 Navigate to the `Campaigns` menu from your dashboard, then into the `Templates` submenu. Find the template you just imported, and copy the number after `#` under the name of the template.
 
 ### UWPSC api
-**_Note: You will also need to have the [API server](https://github.com/uwpokerclub/api) running locally as well._**
+**_Note: You will also need to have the [API server](https://github.com/uwpokerclub/website/tree/master/server) running locally as well._**
 
-**uwpsc.uwpsc.apiUrl:** where the api is hosted.\
+**uwpsc.uwpsc.apiUrl:** where the api is hosted, **including the `/api/v2` path prefix** — for example `http://localhost:8080/api/v2`. The bot speaks v2 only; pointing this at the legacy `/api` routes will fail, because v1 returns bare arrays where v2 returns `{ data, total }`.\
 **cookieName:** the name of the authentication cookie. Likely going to be one of `uwpsc-session-id` or `uwpsc-dev-session-id`.\
 **uwpsc.username & uwpsc.password:** login credentials.
 

--- a/config.example.json
+++ b/config.example.json
@@ -11,7 +11,7 @@
     "verification_email_template_id": "EMAIL_TEMPLATE_ID_HERE"
   },
   "uwpsc": {
-      "apiUrl": "BACKEND_URL_HERE",
+      "apiUrl": "BACKEND_URL_HERE/api/v2",
       "cookieName": "AUTH_COOKIE_NAME_HERE",
       "username": "API_CRED_USERNAME_HERE", 
       "password": "API_CRED_PASSWORD_HERE"

--- a/src/base/api/types.ts
+++ b/src/base/api/types.ts
@@ -1,14 +1,12 @@
 // TypeScript mirrors of the uwpokerclub/website v2 API response models.
 // Source of truth: server/internal/models/ in that repository.
 
-
 // Envelope returned by every v2 list endpoint. Single-resource endpoints
 // return the bare object instead.
 export interface ListResponse<T> {
     data: T[];
     total: number;
 }
-
 
 // models.User, serialized as "Member" by the v2 members controller.
 export interface Member {
@@ -20,7 +18,6 @@ export interface Member {
     questId: string;
     createdAt: string;
 }
-
 
 export interface Semester {
     id: string;
@@ -35,14 +32,12 @@ export interface Semester {
     rebuyFee: number;
 }
 
-
 export interface Ranking {
     id: number;
     membershipId: string;
     points: number;
     attendance: number;
 }
-
 
 export interface Membership {
     id: string;
@@ -55,12 +50,10 @@ export interface Membership {
     ranking: Ranking | null;
 }
 
-
 // Returned by GET /semesters/{semesterId}/memberships.
 export interface MembershipWithAttendance extends Membership {
     attendance: number;
 }
-
 
 // Returned by GET /semesters/{semesterId}/rankings.
 export interface RankingResponse {
@@ -70,7 +63,6 @@ export interface RankingResponse {
     points: number;
     position: number;
 }
-
 
 // Returned by GET /semesters/{semesterId}/rankings/{membershipId}.
 export interface GetRankingResponse {

--- a/src/base/api/types.ts
+++ b/src/base/api/types.ts
@@ -1,0 +1,79 @@
+// TypeScript mirrors of the uwpokerclub/website v2 API response models.
+// Source of truth: server/internal/models/ in that repository.
+
+
+// Envelope returned by every v2 list endpoint. Single-resource endpoints
+// return the bare object instead.
+export interface ListResponse<T> {
+    data: T[];
+    total: number;
+}
+
+
+// models.User, serialized as "Member" by the v2 members controller.
+export interface Member {
+    id: number;
+    firstName: string;
+    lastName: string;
+    email: string;
+    faculty: string;
+    questId: string;
+    createdAt: string;
+}
+
+
+export interface Semester {
+    id: string;
+    name: string;
+    meta: string;
+    startDate: string;
+    endDate: string;
+    startingBudget: number;
+    currentBudget: number;
+    membershipFee: number;
+    membershipDiscountFee: number;
+    rebuyFee: number;
+}
+
+
+export interface Ranking {
+    id: number;
+    membershipId: string;
+    points: number;
+    attendance: number;
+}
+
+
+export interface Membership {
+    id: string;
+    userId: number;
+    user: Member | null;
+    semesterId: string;
+    semester: Semester | null;
+    paid: boolean;
+    discounted: boolean;
+    ranking: Ranking | null;
+}
+
+
+// Returned by GET /semesters/{semesterId}/memberships.
+export interface MembershipWithAttendance extends Membership {
+    attendance: number;
+}
+
+
+// Returned by GET /semesters/{semesterId}/rankings.
+export interface RankingResponse {
+    id: number;
+    firstName: string;
+    lastName: string;
+    points: number;
+    position: number;
+}
+
+
+// Returned by GET /semesters/{semesterId}/rankings/{membershipId}.
+export interface GetRankingResponse {
+    points: number;
+    position: number;
+}

--- a/src/base/api/uwpsc.ts
+++ b/src/base/api/uwpsc.ts
@@ -10,23 +10,19 @@ import type {
     Semester,
 } from "./types.js";
 
-
 function isNotFound(error: unknown): boolean {
     return axios.isAxiosError(error) && error.response?.status === 404;
 }
 
-
 function sameEmail(a: string, b: string): boolean {
     return a.trim().toLowerCase() === b.trim().toLowerCase();
 }
-
 
 // Ordered by start date descending, so element 0 is the newest semester.
 export async function listSemesters(): Promise<Semester[]> {
     const res = await uwpscApiAxios.get<ListResponse<Semester>>("/semesters");
     return res.data.data;
 }
-
 
 // The API's email filter is a partial ILIKE match, so the result is
 // re-filtered here for an exact (case-insensitive) match.
@@ -36,7 +32,6 @@ export async function findMemberByEmail(email: string): Promise<Member | null> {
     });
     return res.data.data.find(member => sameEmail(member.email, email)) ?? null;
 }
-
 
 // Returns null when no such membership exists in that semester. The endpoint
 // is semester-scoped, so a membership from a different semester is a 404.
@@ -57,7 +52,6 @@ export async function getMembership(
     }
 }
 
-
 // The v2 memberships endpoint has no userId filter, so this queries by email
 // (a partial ILIKE match) and narrows to the exact user client-side.
 export async function findMembership(
@@ -72,7 +66,6 @@ export async function findMembership(
     return res.data.data.find(membership => membership.userId === userId) ?? null;
 }
 
-
 // paid/discounted are sent explicitly: the API rejects paid=false with
 // discounted=true, and an unpaid membership is what the bot has always created.
 export async function createMembership(
@@ -86,7 +79,6 @@ export async function createMembership(
     return res.data;
 }
 
-
 // Capped at 100 entries by the API's max page size.
 export async function listRankings(semesterId: string): Promise<RankingResponse[]> {
     const res = await uwpscApiAxios.get<ListResponse<RankingResponse>>(
@@ -94,7 +86,6 @@ export async function listRankings(semesterId: string): Promise<RankingResponse[
     );
     return res.data.data;
 }
-
 
 // Returns null when the member has registered but has not played an event yet.
 export async function getRanking(

--- a/src/base/api/uwpsc.ts
+++ b/src/base/api/uwpsc.ts
@@ -1,0 +1,115 @@
+import axios from "axios";
+import { uwpscApiAxios } from "../utility/Axios.js";
+import type {
+    GetRankingResponse,
+    ListResponse,
+    Member,
+    Membership,
+    MembershipWithAttendance,
+    RankingResponse,
+    Semester,
+} from "./types.js";
+
+
+function isNotFound(error: unknown): boolean {
+    return axios.isAxiosError(error) && error.response?.status === 404;
+}
+
+
+function sameEmail(a: string, b: string): boolean {
+    return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+
+// Ordered by start date descending, so element 0 is the newest semester.
+export async function listSemesters(): Promise<Semester[]> {
+    const res = await uwpscApiAxios.get<ListResponse<Semester>>("/semesters");
+    return res.data.data;
+}
+
+
+// The API's email filter is a partial ILIKE match, so the result is
+// re-filtered here for an exact (case-insensitive) match.
+export async function findMemberByEmail(email: string): Promise<Member | null> {
+    const res = await uwpscApiAxios.get<ListResponse<Member>>("/members", {
+        params: { email: email },
+    });
+    return res.data.data.find(member => sameEmail(member.email, email)) ?? null;
+}
+
+
+// Returns null when no such membership exists in that semester. The endpoint
+// is semester-scoped, so a membership from a different semester is a 404.
+export async function getMembership(
+    semesterId: string,
+    membershipId: string,
+): Promise<Membership | null> {
+    try {
+        const res = await uwpscApiAxios.get<Membership>(
+            `/semesters/${semesterId}/memberships/${membershipId}`,
+        );
+        return res.data;
+    } catch (error) {
+        if (isNotFound(error)) {
+            return null;
+        }
+        throw error;
+    }
+}
+
+
+// The v2 memberships endpoint has no userId filter, so this queries by email
+// (a partial ILIKE match) and narrows to the exact user client-side.
+export async function findMembership(
+    semesterId: string,
+    email: string,
+    userId: number,
+): Promise<MembershipWithAttendance | null> {
+    const res = await uwpscApiAxios.get<ListResponse<MembershipWithAttendance>>(
+        `/semesters/${semesterId}/memberships`,
+        { params: { email: email } },
+    );
+    return res.data.data.find(membership => membership.userId === userId) ?? null;
+}
+
+
+// paid/discounted are sent explicitly: the API rejects paid=false with
+// discounted=true, and an unpaid membership is what the bot has always created.
+export async function createMembership(
+    semesterId: string,
+    userId: number,
+): Promise<Membership> {
+    const res = await uwpscApiAxios.post<Membership>(
+        `/semesters/${semesterId}/memberships`,
+        { userId: userId, paid: false, discounted: false },
+    );
+    return res.data;
+}
+
+
+// Capped at 100 entries by the API's max page size.
+export async function listRankings(semesterId: string): Promise<RankingResponse[]> {
+    const res = await uwpscApiAxios.get<ListResponse<RankingResponse>>(
+        `/semesters/${semesterId}/rankings`,
+    );
+    return res.data.data;
+}
+
+
+// Returns null when the member has registered but has not played an event yet.
+export async function getRanking(
+    semesterId: string,
+    membershipId: string,
+): Promise<GetRankingResponse | null> {
+    try {
+        const res = await uwpscApiAxios.get<GetRankingResponse>(
+            `/semesters/${semesterId}/rankings/${membershipId}`,
+        );
+        return res.data;
+    } catch (error) {
+        if (isNotFound(error)) {
+            return null;
+        }
+        throw error;
+    }
+}

--- a/src/base/utility/Axios.ts
+++ b/src/base/utility/Axios.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosInstance } from "axios";
+import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from "axios";
 import type IConfig from "../interfaces/IConfig.js";
 import path from "node:path";
 import { createRequire } from "node:module";
@@ -11,6 +11,7 @@ const userAgentValue: string = "UWPSC-Discord-Bot";
 let sessionCookie: string = "";
 export let uwpscApiAxios: AxiosInstance;
 
+type RetriableConfig = InternalAxiosRequestConfig & { _retry?: boolean };
 
 export async function axiosInit() {
     sessionCookie = await login();
@@ -36,13 +37,19 @@ export async function axiosInit() {
     uwpscApiAxios.interceptors.response.use(response => {
         return response;
     }, async error => {
-        if (error.response.status == 401 && !error.config._retry) {
-            error.config._retry = true;
-            
-            sessionCookie = await login();
-            return await uwpscApiAxios(error.config);
+        if (!axios.isAxiosError(error)) {
+            return Promise.reject(error);
         }
-        return error;
+
+        const failedConfig = error.config as RetriableConfig | undefined;
+        if (error.response?.status == 401 && failedConfig && !failedConfig._retry) {
+            failedConfig._retry = true;
+
+            sessionCookie = await login();
+            return await uwpscApiAxios(failedConfig);
+        }
+
+        return Promise.reject(error);
     });
 }
 

--- a/src/commands/Admin/SetCurrentSemester.ts
+++ b/src/commands/Admin/SetCurrentSemester.ts
@@ -1,7 +1,8 @@
 import { ChatInputCommandInteraction, MessageFlags, PermissionFlagsBits, TextChannel } from "discord.js";
 import type BossClient from "../../base/classes/BossClient.js";
 import Command from "../../base/classes/Command.js"; import Category from "../../base/enums/Category.js";
-import { uwpscApiAxios } from "../../base/utility/Axios.js";
+import { listSemesters } from "../../base/api/uwpsc.js";
+import type { Semester } from "../../base/api/types.js";
 import { Configs } from "../../base/db/models/Configs.js";
 import axios from "axios";
 
@@ -22,9 +23,9 @@ export default class SetCurrentSemester extends Command {
     }
 
     override async execute(interaction: ChatInputCommandInteraction) {
-        let semesters = null;
+        let semesters: Semester[] = [];
         try {
-            semesters = await uwpscApiAxios.get("/semesters");
+            semesters = await listSemesters();
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 if (error.response) {
@@ -40,7 +41,7 @@ export default class SetCurrentSemester extends Command {
         }
 
 
-        const currentSemester = semesters.data[0];
+        const currentSemester = semesters[0];
         if (!currentSemester) {
             // should never happen, unless the main db is dropped
             interaction.reply({ content: `System error. Cannot set current semester right now.`, flags: MessageFlags.Ephemeral });

--- a/src/commands/Admin/VerifyMember.ts
+++ b/src/commands/Admin/VerifyMember.ts
@@ -5,7 +5,8 @@ import Category from "../../base/enums/Category.js";
 import { VerificationAttempts } from "../../base/db/models/VerificationAttempts.js";
 import { Members } from "../../base/db/models/Members.js";
 import { VerificationCodes } from "../../base/db/models/VerificationCodes.js";
-import { uwpscApiAxios } from "../../base/utility/Axios.js";
+import { findMemberByEmail } from "../../base/api/uwpsc.js";
+import type { Member } from "../../base/api/types.js";
 import axios from "axios";
 
 
@@ -104,11 +105,9 @@ export default class VerifyMember extends Command {
             return false;
         }
         
-        const res = await uwpscApiAxios.get("/users", {
-            params: {email: modalInputEmail}
-        });     // error is handled by the caller
+        const member = await findMemberByEmail(modalInputEmail);     // error is handled by the caller
 
-        return res.data.length != 0;
+        return member !== null;
     }
 
 
@@ -127,11 +126,9 @@ export default class VerifyMember extends Command {
         await VerificationCodes.destroy({where: {discord_client_id: targetMemberClientId}});
         await VerificationAttempts.destroy({where: {discord_client_id: targetMemberClientId}});
 
-        let userRes;
+        let targetUser: Member | null = null;
         try {
-            userRes = await uwpscApiAxios.get("/users", {
-                params: {email: targetMemberEmail}
-            });
+            targetUser = await findMemberByEmail(targetMemberEmail);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 if (error.response) {
@@ -145,7 +142,9 @@ export default class VerifyMember extends Command {
             return false;
         }
 
-        const targetUser = userRes.data[0];
+        if (targetUser === null) {
+            return false;
+        }
 
         const memberEntry: Members | undefined = (await Members.findAll({
             where: {

--- a/src/commands/Admin/VerifyMember.ts
+++ b/src/commands/Admin/VerifyMember.ts
@@ -86,7 +86,8 @@ export default class VerifyMember extends Command {
             return;
         }
         if (await this.isDuplicateEmail(emailParam)) {
-            interaction.reply({ content: "Verification failed. The given email has already been used by another member to verify their account." })
+            interaction.reply({ content: "Verification failed. The given email has already been used by another member to verify their account.", flags: MessageFlags.Ephemeral });
+            return;
         }
 
         if (await this.processSuccessfulVerification(interaction, targetUserClientId, emailParam)) {

--- a/src/commands/Member/IndividualRanking.ts
+++ b/src/commands/Member/IndividualRanking.ts
@@ -3,7 +3,8 @@ import type BossClient from "../../base/classes/BossClient.js";
 import Command from "../../base/classes/Command.js";
 import Category from "../../base/enums/Category.js";
 import { Members } from "../../base/db/models/Members.js";
-import { uwpscApiAxios } from "../../base/utility/Axios.js";
+import { getMembership, getRanking } from "../../base/api/uwpsc.js";
+import type { GetRankingResponse, Membership } from "../../base/api/types.js";
 import { Configs } from "../../base/db/models/Configs.js";
 import axios from "axios";
 
@@ -52,9 +53,9 @@ export default class IndividualRanking extends Command {
             return;
         }
 
-        let membershipRes;
+        let membership: Membership | null = null;
         try {
-            membershipRes = await uwpscApiAxios.get(`/memberships/${membershipId}`);
+            membership = await getMembership(currentSemesterId, membershipId);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 if (error.response) {
@@ -69,16 +70,15 @@ export default class IndividualRanking extends Command {
             return;
         }
 
-        const recordedMembershipSemesterId : string = membershipRes.data.semesterId;
-        if (recordedMembershipSemesterId != currentSemesterId) {
+        if (membership === null) {
             interaction.reply({ content: "You have not registered for the current semester. Use `/register` to register.", flags: MessageFlags.Ephemeral });
             return;
         }
 
-        
-        let rankingRes;
+
+        let ranking: GetRankingResponse | null = null;
         try {
-            rankingRes = (await uwpscApiAxios.get(`/semesters/${currentSemesterId}/rankings/${membershipId}`));
+            ranking = await getRanking(currentSemesterId, membershipId);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 if (error.response) {
@@ -93,23 +93,23 @@ export default class IndividualRanking extends Command {
             return;
         }
 
-        if (rankingRes.status != 200) {
+        if (ranking === null) {
             // This would only run if the player registered for the current semester, but has yet to play an event
             interaction.reply({ content: "No records of your performance this term can be found.", flags: MessageFlags.Ephemeral });
             return;
         }
 
         const currentSemesterName = currentSemesterConfigRes.dataValues.current_semester_name;
-        const position: string = rankingRes.data.position;
-        const points: string = rankingRes.data.points;
+        const position: number = ranking.position;
+        const points: number = ranking.points;
         let color: ColorResolvable;
         const colorGreen: ColorResolvable = [10, 149, 72];
         const colorYellow: ColorResolvable = [229,162,103];
         const colorRed: ColorResolvable = [163, 0, 0];
 
-        if (parseInt(position) <= 100) {
+        if (position <= 100) {
             color = colorGreen;
-        } else if (parseInt(position) <= 120) {
+        } else if (position <= 120) {
             color = colorYellow;
         } else {
             color = colorRed;

--- a/src/commands/Member/Leaderboard.ts
+++ b/src/commands/Member/Leaderboard.ts
@@ -95,8 +95,8 @@ export default class Leaderboard extends Command {
         let points: string = "";
         const startIndex = (pageNumber - 1) * this.pageSizeDesktop;
         const endIndex = Math.min(startIndex + this.pageSizeDesktop, leaderboardLength);
-        for (const [offset, entry] of data.slice(startIndex, endIndex).entries()) {
-            positions += `${startIndex + offset + 1}\n`;
+        for (const entry of data.slice(startIndex, endIndex)) {
+            positions += `${entry.position}\n`;
             names += `${entry.firstName} ${entry.lastName}\n`;
             points += `${entry.points}\n`;
         }
@@ -124,8 +124,8 @@ export default class Leaderboard extends Command {
         } else {
             const startIndex = (pageNumber - 1) * this.pageSizeMobile;
             const endIndex = Math.min(startIndex + this.pageSizeMobile, leaderboardLength);
-            for (const [offset, entry] of data.slice(startIndex, endIndex).entries()) {
-                rankingEmbed.addFields({ name: `${startIndex + offset + 1}`, value: `${entry.firstName} ${entry.lastName} ---- ${entry.points}`});
+            for (const entry of data.slice(startIndex, endIndex)) {
+                rankingEmbed.addFields({ name: `${entry.position}`, value: `${entry.firstName} ${entry.lastName} ---- ${entry.points}`});
             }
         }
         

--- a/src/commands/Member/Leaderboard.ts
+++ b/src/commands/Member/Leaderboard.ts
@@ -2,7 +2,8 @@ import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChatIn
 import type BossClient from "../../base/classes/BossClient.js";
 import Command from "../../base/classes/Command.js";
 import Category from "../../base/enums/Category.js";
-import { uwpscApiAxios } from "../../base/utility/Axios.js";
+import { listRankings } from "../../base/api/uwpsc.js";
+import type { RankingResponse } from "../../base/api/types.js";
 import { Configs } from "../../base/db/models/Configs.js";
 import axios from "axios";
 
@@ -43,9 +44,9 @@ export default class Leaderboard extends Command {
         const currentSemesterName = currentSemesterConfigRes.dataValues.current_semester_name;
 
         
-        let rankingRes;
+        let rankings: RankingResponse[] = [];
         try {
-            rankingRes = (await uwpscApiAxios.get(`/semesters/${currentSemesterId}/rankings`));
+            rankings = await listRankings(currentSemesterId);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 if (error.response) {
@@ -59,11 +60,11 @@ export default class Leaderboard extends Command {
             interaction.reply({ content: "System error. Please try again later.", flags: MessageFlags.Ephemeral });
             return;
         }
-        const leaderboardLength: number = Math.min(rankingRes.data.length, 100);
+        const leaderboardLength: number = Math.min(rankings.length, 100);
 
         let pageNumber: number = 1;
         let mobileMode: boolean = true;
-        const rankingEmbed = this.getUpdatedRankingEmbed(rankingRes.data, pageNumber, currentSemesterName, leaderboardLength, mobileMode);
+        const rankingEmbed = this.getUpdatedRankingEmbed(rankings, pageNumber, currentSemesterName, leaderboardLength, mobileMode);
         const buttonRow = this.getUpdatedRankingButtonRow(interaction.id, pageNumber, leaderboardLength, mobileMode);
 
         const response = await interaction.reply({ components: [buttonRow], embeds: [rankingEmbed], flags: MessageFlags.Ephemeral });
@@ -80,7 +81,7 @@ export default class Leaderboard extends Command {
                 return;
             }
 
-            const rankingEmbed = this.getUpdatedRankingEmbed(rankingRes.data, pageNumber, currentSemesterName, leaderboardLength, mobileMode);
+            const rankingEmbed = this.getUpdatedRankingEmbed(rankings, pageNumber, currentSemesterName, leaderboardLength, mobileMode);
             const buttonRow = this.getUpdatedRankingButtonRow(interaction.id, pageNumber, leaderboardLength, mobileMode);
             await buttonInteraction.update({ components: [buttonRow], embeds: [rankingEmbed] });
         
@@ -88,21 +89,22 @@ export default class Leaderboard extends Command {
     }
 
 
-    private getLeaderboardDesktopPage(data: any, pageNumber: number, leaderboardLength: number): {positions: string, names: string, points: string} {
+    private getLeaderboardDesktopPage(data: RankingResponse[], pageNumber: number, leaderboardLength: number): {positions: string, names: string, points: string} {
         let positions: string = "";
         let names: string = "";
         let points: string = "";
         const startIndex = (pageNumber - 1) * this.pageSizeDesktop;
-        for (let i=startIndex; i<startIndex + Math.min(leaderboardLength - startIndex, this.pageSizeDesktop); i++) {
-            positions += `${i+1}\n`;
-            names += `${data[i].firstName} ${data[i].lastName}\n`;
-            points += `${data[i].points}\n`;
+        const endIndex = Math.min(startIndex + this.pageSizeDesktop, leaderboardLength);
+        for (const [offset, entry] of data.slice(startIndex, endIndex).entries()) {
+            positions += `${startIndex + offset + 1}\n`;
+            names += `${entry.firstName} ${entry.lastName}\n`;
+            points += `${entry.points}\n`;
         }
         return {positions: positions, names: names, points: points};
     }
 
 
-    private getUpdatedRankingEmbed(data: any, pageNumber: number, currentSemesterName: string, leaderboardLength: number, mobileMode: boolean): EmbedBuilder {
+    private getUpdatedRankingEmbed(data: RankingResponse[], pageNumber: number, currentSemesterName: string, leaderboardLength: number, mobileMode: boolean): EmbedBuilder {
         const easternNowTimeString: string = new Date().toLocaleString("en-US", { timeZone: "America/Toronto" })
         const now: Date = new Date(easternNowTimeString);
         const calendarDate: string = `${now.getFullYear()}/${now.getMonth() + 1}/${now.getDate()} Eastern Time`;
@@ -121,8 +123,9 @@ export default class Leaderboard extends Command {
             );
         } else {
             const startIndex = (pageNumber - 1) * this.pageSizeMobile;
-            for (let i=startIndex; i<startIndex + Math.min(leaderboardLength - startIndex, this.pageSizeMobile); i++) {
-                rankingEmbed.addFields({ name: `${i+1}`, value: `${data[i].firstName} ${data[i].lastName} ---- ${data[i].points}`});
+            const endIndex = Math.min(startIndex + this.pageSizeMobile, leaderboardLength);
+            for (const [offset, entry] of data.slice(startIndex, endIndex).entries()) {
+                rankingEmbed.addFields({ name: `${startIndex + offset + 1}`, value: `${entry.firstName} ${entry.lastName} ---- ${entry.points}`});
             }
         }
         

--- a/src/commands/Member/Register.ts
+++ b/src/commands/Member/Register.ts
@@ -2,7 +2,8 @@ import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, ChatIn
 import type BossClient from "../../base/classes/BossClient.js";
 import Command from "../../base/classes/Command.js";
 import Category from "../../base/enums/Category.js";
-import { uwpscApiAxios } from "../../base/utility/Axios.js";
+import { createMembership, findMembership } from "../../base/api/uwpsc.js";
+import type { Membership, MembershipWithAttendance } from "../../base/api/types.js";
 import { Configs } from "../../base/db/models/Configs.js";
 import { Members } from "../../base/db/models/Members.js";
 import axios from "axios";
@@ -35,7 +36,9 @@ export default class Register extends Command {
         }
 
         const clientId: string = interaction.user.id;
-        const userId = (await Members.findAll({ where: { discord_client_id: clientId } }))[0]?.dataValues.user_id;
+        const memberRecord = (await Members.findAll({ where: { discord_client_id: clientId } }))[0];
+        const userId = memberRecord?.dataValues.user_id;
+        const email = memberRecord?.dataValues.email;
         const currentSemesterConfigRes = (await Configs.findAll())[0];
         if (!currentSemesterConfigRes) {
             interaction.reply({ content: "Cannot register at the moment, please try again later.", flags: MessageFlags.Ephemeral });
@@ -65,11 +68,9 @@ export default class Register extends Command {
             await interaction.editReply({ content: `Processing...`, components: [] });
             
             if (buttonInteraction.customId == `confirmRegisterButton-${interaction.id}`) {
-                let existingMembershipRes;
+                let existingMembership: MembershipWithAttendance | null = null;
                 try {
-                    existingMembershipRes = await uwpscApiAxios.get("/memberships", {
-                        params: {userId: userId, semesterId: currentSemesterId}
-                    });
+                    existingMembership = await findMembership(currentSemesterId, email, userId);
                 } catch (error) {
                     if (axios.isAxiosError(error)) {
                         if (error.response) {
@@ -83,15 +84,12 @@ export default class Register extends Command {
                     interaction.reply({ content: "System error. Please try again later.", flags: MessageFlags.Ephemeral });
                     return;
                 }
-                const existingMembership = existingMembershipRes.data[0];
 
                 let membershipId: string;
                 if (existingMembership == undefined) {
-                    let newMembership;
+                    let newMembership: Membership | null = null;
                     try {
-                        newMembership = await uwpscApiAxios.post("/memberships", {
-                            userId: userId, semesterId: currentSemesterId
-                        });
+                        newMembership = await createMembership(currentSemesterId, userId);
                     } catch (error) {
                         if (axios.isAxiosError(error)) {
                             if (error.response) {
@@ -105,7 +103,7 @@ export default class Register extends Command {
                         interaction.reply({ content: "System error. Please try again later.", flags: MessageFlags.Ephemeral });
                         return;
                     }
-                    membershipId = newMembership.data.id;
+                    membershipId = newMembership.id;
                 } else {
                     membershipId = existingMembership.id;
                 }

--- a/src/commands/Member/Register.ts
+++ b/src/commands/Member/Register.ts
@@ -39,6 +39,11 @@ export default class Register extends Command {
         const memberRecord = (await Members.findAll({ where: { discord_client_id: clientId } }))[0];
         const userId = memberRecord?.dataValues.user_id;
         const email = memberRecord?.dataValues.email;
+        if (userId === undefined || email === undefined) {
+            interaction.reply({ content: "Something went wrong. Please `/logout` and re-verify your account again, or contact an admin for help.", flags: MessageFlags.Ephemeral });
+            return;
+        }
+
         const currentSemesterConfigRes = (await Configs.findAll())[0];
         if (!currentSemesterConfigRes) {
             interaction.reply({ content: "Cannot register at the moment, please try again later.", flags: MessageFlags.Ephemeral });

--- a/src/interactionMangers/buttonManagers/VerifierButtonManager.ts
+++ b/src/interactionMangers/buttonManagers/VerifierButtonManager.ts
@@ -1,7 +1,8 @@
 import { ActionRowBuilder, ButtonInteraction, ModalSubmitInteraction, GuildMember, GuildMemberRoleManager, MessageFlags, ModalBuilder, Role, TextInputBuilder, TextInputStyle } from "discord.js";
 import type BossClient from "../../base/classes/BossClient.js";
 import ButtonManager from "../../base/classes/ButtonManager.js";
-import { uwpscApiAxios } from "../../base/utility/Axios.js";
+import { createMembership, findMemberByEmail, findMembership } from "../../base/api/uwpsc.js";
+import type { Member, Membership, MembershipWithAttendance } from "../../base/api/types.js";
 import { Members } from "../../base/db/models/Members.js";
 import { VerificationCodes } from "../../base/db/models/VerificationCodes.js";
 import { VerificationAttempts } from "../../base/db/models/VerificationAttempts.js";
@@ -274,16 +275,9 @@ export default class VerifierButtonManager extends ButtonManager {
             return false;
         }
         
-        const res = await uwpscApiAxios.get("/users", {
-            params: {email: modalInputEmail}
-        });     // throws error if applicable, the caller should handle it
+        const member = await findMemberByEmail(modalInputEmail);     // throws error if applicable, the caller should handle it
 
-        if (!(res.data.length != 0)) {
-            return false;
-        }
-        return true;
-        
-
+        return member !== null;
     }
 
     private async isDuplicateEmail(modalInputEmail: string): Promise<boolean> {
@@ -336,11 +330,9 @@ export default class VerifierButtonManager extends ButtonManager {
 
         const email: string = (await this.getUserEmail(buttonInteraction.user.id))!;
 
-        let userRes;
+        let targetUser: Member | null = null;
         try {
-            userRes = await uwpscApiAxios.get("/users", {
-                params: {email: email}
-            });
+            targetUser = await findMemberByEmail(email);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 if (error.response) {
@@ -355,7 +347,10 @@ export default class VerifierButtonManager extends ButtonManager {
             return;
         }
 
-        const targetUser = userRes.data[0];
+        if (targetUser === null) {
+            buttonInteraction.followUp({ content: `**Verification failed**. System error. Please try again later`, flags: MessageFlags.Ephemeral });
+            return;
+        }
 
         await Members.update(
             { 
@@ -367,10 +362,10 @@ export default class VerifierButtonManager extends ButtonManager {
         this.assignVerifiedRole(buttonInteraction);
         buttonInteraction.followUp({ content: `**Verification successful**. Your discord account is now linked to ${email}!`, flags: MessageFlags.Ephemeral });
         
-        await this.currentSemesterRegistration(buttonInteraction, targetUser.id);
+        await this.currentSemesterRegistration(buttonInteraction, targetUser.id, email);
     }
 
-    private async currentSemesterRegistration(buttonInteraction: ButtonInteraction, userId: number) {
+    private async currentSemesterRegistration(buttonInteraction: ButtonInteraction, userId: number, email: string) {
         const currentSemesterConfigRes = (await Configs.findAll())[0];
         if (!currentSemesterConfigRes) {
             buttonInteraction.followUp({ content: "Cannot register to the current semester at the moment. Please use `/register` later.", flags: MessageFlags.Ephemeral });
@@ -381,11 +376,9 @@ export default class VerifierButtonManager extends ButtonManager {
         const currentSemesterName = currentSemesterConfigRes.dataValues.current_semester_name;
 
 
-        let existingMembershipRes;
+        let existingMembership: MembershipWithAttendance | null = null;
         try {
-            existingMembershipRes = await uwpscApiAxios.get("/memberships", {
-                params: {userId: userId, semesterId: currentSemesterId}
-            });
+            existingMembership = await findMembership(currentSemesterId, email, userId);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 if (error.response) {
@@ -398,15 +391,12 @@ export default class VerifierButtonManager extends ButtonManager {
             }
             return;
         }
-        const existingMembership = existingMembershipRes.data[0];
 
         let membershipId: string;
         if (existingMembership == undefined) {
-            let newMembership;
+            let newMembership: Membership | null = null;
             try {
-                newMembership  = (await uwpscApiAxios.post("/memberships", {
-                    userId: userId, semesterId: currentSemesterId
-                }));
+                newMembership = await createMembership(currentSemesterId, userId);
             } catch (error) {
                 if (axios.isAxiosError(error)) {
                     if (error.response) {
@@ -419,7 +409,7 @@ export default class VerifierButtonManager extends ButtonManager {
                 }
                 return;
             }
-            membershipId = newMembership.data.id;
+            membershipId = newMembership.id;
         } else {
             membershipId = existingMembership.id;
         }


### PR DESCRIPTION
## Description
Migrates every UWPSC API call in pit-boss-bot from the legacy v1 `/api` routes to the v2 `/api/v2` routes served by `uwpokerclub/website`, behind a new typed API module (`src/base/api/`), without changing any user-facing Discord behaviour.

Key changes:
- `src/base/api/types.ts` and `src/base/api/uwpsc.ts`: new typed module that owns the v2 contract — endpoint paths, the `{data, total}` list envelope, response types, and the 404→`null` convention.
- `src/base/utility/Axios.ts`: the response interceptor now actually rejects failed requests instead of resolving with the error object, and guards against responseless (network) errors. This is what makes the 404→`null` pattern possible.
- All seven call sites (`/setcurrentsemester`, `/leaderboard`, `/ranking`, `/register`, `/verifymember`, and the four calls in the verifier button flow) migrated to the new module, keeping their existing `try`/`catch` shape.
- `config.example.json` and `README.md` updated to document the required `/api/v2` path prefix.
- Two bugs found and fixed during manual end-to-end testing against a locally seeded v2 API:
  - `/leaderboard` numbered rows sequentially instead of using the API's real (tie-aware) `position` field, so tied players displayed different position numbers than `/ranking` showed for the same person.
  - `/verifymember` was missing a `return` after its duplicate-email rejection, so it fell through and called `interaction.reply()` a second time on the same interaction, crashing the bot process.

**Deployment note:** cutover requires updating the deployed `apiUrl` config to include `/api/v2` at the same time this code deploys — the code no longer understands v1's bare-array responses, so a config-only or code-only rollout will break the bot in both directions. Rollback likewise requires reverting both code and config together.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing completed

This repo has no test framework (`npm test` is a stub); verification was `npm run build` after every change, plus manual end-to-end testing against a locally seeded v2 API and a real Discord test bot, covering: semester selection, leaderboard (mobile/desktop, paging, partial last page, tied positions), individual ranking (has points / no ranking yet / not registered this semester), registration (fresh / already registered / re-registration after deletion), the verifier button flow (valid email / invalid email, including the auto-registration side effect), admin verification via `/verifymember`, and the session-expiry/re-login path.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added for new functionality
- [x] Documentation updated
